### PR TITLE
"Allow multiple merchants" option in adyen payment method default settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ You can create issues on our Magento Repository or if you have some specific pro
 
 <h2>Offical Releases</h2>
 [Click here to see and download the official releases of the Adyen Payment module](https://github.com/Adyen/magento/releases)
+
+<h2>Update script to 2.4.0 for Adyen OneClick users</h2>
+In the new version of the module 2.4.0 the Recurring References are saved into the Billing Agreements of Magento.
+If you already running the Adyen plugin that has version 2.3.1 or lower you need to import the already saved card data into your Magento store if you want to show OneClick to your current shoppers.
+
+To import the current saved cards into billing agreements of Magento you need to manually execute the script by following these steps:
+1. Go into your terminal
+2. Go to the Magento home directory
+3. Go inside the folder shell
+4. Now execute the script by: php adyen.php -action loadBillingAgreements
+
+All new saved cards will be automatically saved into billingAgreement of magento. Make sure you have turned on RECURRING_CONTRACT notification on your merchantAccount. If you want to add this or if you are not sure, just send us an email us magento@adyen.com.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can create issues on our Magento Repository or if you have some specific pro
 <h2>Offical Releases</h2>
 [Click here to see and download the official releases of the Adyen Payment module](https://github.com/Adyen/magento/releases)
 
-<h2>Update script to 2.4.0 for Adyen OneClick users</h2>
+<h2>Update script for 2.4.0 for Adyen OneClick users</h2>
 In the new version of the module 2.4.0 the Recurring References are saved into the Billing Agreements of Magento.
 If you already running the Adyen plugin that has version 2.3.1 or lower you need to import the already saved card data into your Magento store if you want to show OneClick to your current shoppers.
 


### PR DESCRIPTION
This option disables the check on merchant account when notifications are
received. This makes it possible to use multiple merchant accounts in one
magento environment. (one merchant account per website for instance)
